### PR TITLE
fix: in CI, install python modules in system python path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ on:
       - edited
       - synchronize
 
-env:
-  UV_PROJECT_ENVIRONMENT: ${{ env.pythonLocation }}
-
 jobs:
   lint:
     runs-on: ubuntu-24.04
@@ -38,7 +35,7 @@ jobs:
           cache-dependency-glob: 'requirements**.txt'
 
       - name: Install Python dependencies
-        run: make install-dev
+        run: make install-dev DC_ENV=ci
 
       - name: Run lint checks
         run: make lint
@@ -74,8 +71,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          make install
-          make install-dev
+          make install DC_ENV=ci
+          make install-dev DC_ENV=ci
 
       - name: Restore data cache
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+ifeq ($(DC_ENV),ci)
+	UV_FLAGS = "--system"
+endif
+
 install:
-	uv pip install -r requirements.txt
+	uv pip install -r requirements.txt $(UV_FLAGS)
 
 install-dev:
-	uv pip install -r requirements-dev.txt
+	uv pip install -r requirements-dev.txt $(UV_FLAGS)
 
 setup-git-hooks:
 	@cp scripts/commit-msg.sample .git/hooks/commit-msg


### PR DESCRIPTION
## Description
In CI, install python modules in system python path.

Fixes YAML error with `env`. Matches terraso-backend behaviour.