### PR TITLE
Fix: revised depth logic to handle custom depths

### DIFF
--- a/soil_id/tests/us/test_us.py
+++ b/soil_id/tests/us/test_us.py
@@ -41,7 +41,8 @@ test_locations = [
 def test_soil_location():
     # Dummy Soil Profile Data (replicating the structure provided)
     soilHorizon = ["LOAM"] * 7
-    horizonDepth = [1, 10, 20, 50, 70, 100, 120]
+    topDepth = [0, 1, 10, 20, 50, 70, 100]
+    bottomDepth = [1, 10, 20, 50, 70, 100, 120]
     rfvDepth = ["0-1%"] * 7
     lab_Color = [[41.24, 2.54, 21.17]] * 7
     bedrock = None
@@ -59,7 +60,8 @@ def test_soil_location():
             item["lat"],
             list_soils_result,
             soilHorizon,
-            horizonDepth,
+            topDepth,
+            bottomDepth,
             rfvDepth,
             lab_Color,
             pSlope,
@@ -76,7 +78,8 @@ def test_empty_rank():
         test_locations[0]["lat"],
         SoilListOutputData,
         soilHorizon=[],
-        horizonDepth=[],
+        topDepth=[],
+        bottomDepth=[],
         rfvDepth=[],
         lab_Color=[],
         pSlope=None,

--- a/soil_id/us_soil.py
+++ b/soil_id/us_soil.py
@@ -2169,6 +2169,7 @@ def rank_soils(
 
     return output_data
 
+
 def adjust_depth_interval(data, target_length=200):
     """Adjusts the depth interval of user data."""
 
@@ -2195,6 +2196,7 @@ def adjust_depth_interval(data, target_length=200):
 
     data.reset_index(drop=True, inplace=True)
     return data
+
 
 # Helper function to update dataframes based on depth conditions
 def update_intpl_data(

--- a/soil_id/us_soil.py
+++ b/soil_id/us_soil.py
@@ -1534,7 +1534,8 @@ def rank_soils(
     lat,
     list_output_data: SoilListOutputData,
     soilHorizon,
-    horizonDepth,
+    topDepth,
+    bottomDepth,
     rfvDepth,
     lab_Color,
     pSlope,
@@ -1553,7 +1554,8 @@ def rank_soils(
     soil_df = pd.DataFrame(
         {
             "soilHorizon": soilHorizon,
-            "horizonDepth": horizonDepth,
+            "top": topDepth,
+            "bottom": bottomDepth,
             "rfvDepth": rfvDepth,
             "lab_Color": lab_Color,
         }
@@ -1562,14 +1564,8 @@ def rank_soils(
     # Drop rows where all values are NaN
     soil_df.dropna(how="all", inplace=True)
 
-    # Set the bottom of each horizon
-    soil_df["bottom"] = soil_df["horizonDepth"]
-
     # Replace NaNs with None for consistency
     # soil_df.fillna(value=None, inplace=True)
-
-    # Calculate the top depth for each horizon
-    soil_df["top"] = [0] + soil_df["horizonDepth"].iloc[:-1].tolist()
 
     # Adjust the bottom depth based on bedrock depth
     if bedrock is not None:
@@ -1580,9 +1576,6 @@ def rank_soils(
             soil_df = soil_df.loc[:last_valid_index].copy()
             # Set the bottom depth of the last row to the bedrock depth
             soil_df.at[last_valid_index, "bottom"] = bedrock
-
-    # Drop the original horizonDepth column
-    soil_df.drop(columns=["horizonDepth"], inplace=True)
 
     # Filter out rows without valid horizon data
     relevant_columns = ["soilHorizon", "rfvDepth", "lab_Color"]

--- a/soil_id/us_soil.py
+++ b/soil_id/us_soil.py
@@ -276,7 +276,8 @@ def list_soils(lon, lat):
     snd_lyrs = []
     cly_lyrs = []
     txt_lyrs = []
-    hz_lyrs = []
+    hzt_lyrs = []
+    hzb_lyrs = []
     rf_lyrs = []
     cec_lyrs = []
     ph_lyrs = []
@@ -329,6 +330,7 @@ def list_soils(lon, lat):
             OSD_rfv_int.append("No")
 
         # extract horizon data
+        hz_dept = group_sorted["hzdept_r"]
         hz_depb = group_sorted["hzdepb_r"]
         snd_d = group_sorted["sandtotal_r"]
         cly_d = group_sorted["claytotal_r"]
@@ -338,6 +340,7 @@ def list_soils(lon, lat):
         ec_d = group_sorted["EC"]
         ph_d = group_sorted["pH"]
 
+        hz_dept = hz_dept.fillna("")
         hz_depb = hz_depb.fillna("")
         snd_d = snd_d.fillna("")
         cly_d = cly_d.fillna("")
@@ -353,7 +356,8 @@ def list_soils(lon, lat):
         cec_lyrs.append(dict(zip(cec_d.index, cec_d)))
         ph_lyrs.append(dict(zip(ph_d.index, ph_d)))
         ec_lyrs.append(dict(zip(ec_d.index, ec_d)))
-        hz_lyrs.append(dict(zip(hz_depb.index, hz_depb)))
+        hzt_lyrs.append(dict(zip(hz_dept.index, hz_dept)))
+        hzb_lyrs.append(dict(zip(hz_depb.index, hz_depb)))
 
         cokey_group = group_sorted["cokey"].iloc[0]
         compname_group = group_sorted["compname"].iloc[0]
@@ -933,8 +937,8 @@ def list_soils(lon, lat):
                         # empty string
                         for lyr in [cec_lyrs, ph_lyrs, ec_lyrs]:
                             if len(lyr[index]) == 1 and lyr[index][0] == "":
-                                empty_values = [""] * len(hz_lyrs[index])
-                                lyr[index] = dict(zip(hz_lyrs[index], empty_values))
+                                empty_values = [""] * len(hzb_lyrs[index])
+                                lyr[index] = dict(zip(hzb_lyrs[index], empty_values))
 
                 else:
                     OSDhorzdata_group_cokey[index] = group_sorted
@@ -948,12 +952,12 @@ def list_soils(lon, lat):
                     lab_intpl_lyrs.append(lab_intpl)
 
                     # Create dummy data for lab_lyrs
-                    lab_dummy = [["", "", ""] for _ in range(len(hz_lyrs[index]))]
-                    lab_lyrs.append(dict(zip(hz_lyrs[index].keys(), lab_dummy)))
+                    lab_dummy = [["", "", ""] for _ in range(len(hzb_lyrs[index]))]
+                    lab_lyrs.append(dict(zip(hzb_lyrs[index].keys(), lab_dummy)))
 
                     # Create dummy data for munsell_lyrs
-                    munsell_dummy = [""] * len(hz_lyrs[index])
-                    munsell_lyrs.append(dict(zip(hz_lyrs[index].keys(), munsell_dummy)))
+                    munsell_dummy = [""] * len(hzb_lyrs[index])
+                    munsell_lyrs.append(dict(zip(hzb_lyrs[index].keys(), munsell_dummy)))
 
             # Series URL Generation
             # Initialize lists to store series URLs
@@ -1001,7 +1005,7 @@ def list_soils(lon, lat):
                 lab_intpl_lyrs.append(lab_intpl)
 
                 # Create dummy data for lab and munsell layers
-                keys = list(hz_lyrs[i].keys())
+                keys = list(hzb_lyrs[i].keys())
                 lab_dummy = [{"", "", ""} for _ in range(len(keys))]
                 munsell_dummy = [""] * len(keys)
 
@@ -1032,7 +1036,7 @@ def list_soils(lon, lat):
             lab_intpl_lyrs.append(lab_intpl)
 
             # Create dummy data for lab and munsell layers
-            keys = list(hz_lyrs[i].keys())
+            keys = list(hzb_lyrs[i].keys())
             lab_dummy = [{"", "", ""} for _ in range(len(keys))]
             munsell_dummy = [""] * len(keys)
 
@@ -1078,7 +1082,8 @@ def list_soils(lon, lat):
             cec_lyrs,
             ph_lyrs,
             ec_lyrs,
-            hz_lyrs,
+            hzt_lyrs,
+            hzb_lyrs,
             lab_lyrs,
             munsell_lyrs,
         ]
@@ -1098,7 +1103,8 @@ def list_soils(lon, lat):
             cec_lyrs,
             ph_lyrs,
             ec_lyrs,
-            hz_lyrs,
+            hzt_lyrs,
+            hzb_lyrs,
             lab_lyrs,
             munsell_lyrs,
         ) = layer_lists
@@ -1433,7 +1439,8 @@ def list_soils(lon, lat):
     # Reordering lists using list comprehension and mucomp_index
     lists_to_reorder = [
         esd_comp_list,
-        hz_lyrs,
+        hzt_lyrs,
+        hzb_lyrs,
         snd_lyrs,
         cly_lyrs,
         txt_lyrs,
@@ -1449,7 +1456,8 @@ def list_soils(lon, lat):
     # Destructuring reordered lists for clarity
     (
         esd_comp_list,
-        hz_lyrs,
+        hzt_lyrs,
+        hzb_lyrs,
         snd_lyrs,
         cly_lyrs,
         txt_lyrs,
@@ -1469,6 +1477,7 @@ def list_soils(lon, lat):
                     "id",
                     "site",
                     "esd",
+                    "top_depth",
                     "bottom_depth",
                     "sand",
                     "clay",
@@ -1487,7 +1496,8 @@ def list_soils(lon, lat):
             ID,
             Site,
             esd_comp_list,
-            hz_lyrs,
+            hzt_lyrs,
+            hzb_lyrs,
             snd_lyrs,
             cly_lyrs,
             txt_lyrs,
@@ -1818,6 +1828,7 @@ def rank_soils(
                         .drop(["compname"], axis=1)
                         .columns.tolist()
                     )
+
                 sliceT = sliceT[sample_pedon_slice_vars]
 
             D = gower_distances(sliceT)  # Equal weighting given to all soil variables
@@ -2158,7 +2169,6 @@ def rank_soils(
 
     return output_data
 
-
 def adjust_depth_interval(data, target_length=200):
     """Adjusts the depth interval of user data."""
 
@@ -2185,7 +2195,6 @@ def adjust_depth_interval(data, target_length=200):
 
     data.reset_index(drop=True, inplace=True)
     return data
-
 
 # Helper function to update dataframes based on depth conditions
 def update_intpl_data(


### PR DESCRIPTION
## Description
PR addresses issue #251. Modifies depth handling logic to accept custom depth intervals. US 'rank_soils' function now requires the top and bottom depth measurements for each soil layer.
