### PR TITLE
fix: Make db image with typos fixed, also fix dockerfile variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN echo "local   all             all                                     trust"
  && chown ${POSTGRES_USER}:${POSTGRES_USER} /var/lib/postgresql/data/pg_hba.conf
 
 ENV POSTGRES_DB=${POSTGRES_DB}
-ENV POSTGRES_USER={POSTGRES_USER}
+ENV POSTGRES_USER=${POSTGRES_USER}
 ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
 USER ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: soil_id
 
 services:
   db:
-    image: ghcr.io/techmatters/soil-id-db:0.2
+    image: ghcr.io/techmatters/soil-id-db:0.3
     ports: 
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Description
This will fix a few typos in the hwsd2_data table: 

- Luvsiols --> Luvisols
- Albic Luvsiols --> Albic Luvisols
- Calcicols --> Calcisols
- CHERNOZEMS --> Chernozems

Walked with garo through updating the db in my local docker container, creating a dump file, building a new image for the db, and pushing it to our [GitHub registry](https://github.com/orgs/techmatters/packages/container/package/soil-id-db) with tags "0.3" and "latest"

Also added `$` in front of the `POSTGRES_USER` variable in the dockerfile :)

### Related Issues
Addresses typos as part of [#1626](https://github.com/techmatters/terraso-backend/issues/1626)

### Verification steps
I'll need to update the staging db once this is confirmed good
