### PR TITLE
fix: remove legacy score normalization (#259)

### DIFF
--- a/soil_id/global_soil.py
+++ b/soil_id/global_soil.py
@@ -1143,9 +1143,6 @@ def rank_soils_global(
         ):
             D_final_loc.at[i, "Score_Data_Loc"] = 0.001
 
-    D_final_loc["Score_Data_Loc"] = D_final_loc["Score_Data_Loc"] / np.nanmax(
-        D_final_loc["Score_Data_Loc"]
-    )
     D_final_loc = D_final_loc.sort_values(["Score_Data_Loc", "compname"], ascending=[False, True])
 
     # Sorting and reindexing of final dataframe

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-1.75,13.6].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-1.75,13.6].json
@@ -731,7 +731,7 @@
         "rank_data_loc": "1",
         "rank_loc": 2,
         "score_data": 0.571,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.435,
         "score_loc": 0.3
       },
       {
@@ -743,7 +743,7 @@
         "rank_data_loc": "2",
         "rank_loc": 1,
         "score_data": 0.35,
-        "score_data_loc": 0.9,
+        "score_data_loc": 0.392,
         "score_loc": 0.433
       },
       {
@@ -755,7 +755,7 @@
         "rank_data_loc": "3",
         "rank_loc": 4,
         "score_data": 0.621,
-        "score_data_loc": 0.809,
+        "score_data_loc": 0.352,
         "score_loc": 0.083
       },
       {
@@ -767,7 +767,7 @@
         "rank_data_loc": "4",
         "rank_loc": 5,
         "score_data": 0.571,
-        "score_data_loc": 0.675,
+        "score_data_loc": 0.294,
         "score_loc": 0.017
       },
       {
@@ -779,7 +779,7 @@
         "rank_data_loc": "5",
         "rank_loc": 6,
         "score_data": 0.519,
-        "score_data_loc": 0.615,
+        "score_data_loc": 0.268,
         "score_loc": 0.017
       },
       {
@@ -791,7 +791,7 @@
         "rank_data_loc": "6",
         "rank_loc": 7,
         "score_data": 0.517,
-        "score_data_loc": 0.613,
+        "score_data_loc": 0.267,
         "score_loc": 0.017
       },
       {
@@ -803,7 +803,7 @@
         "rank_data_loc": "7",
         "rank_loc": 3,
         "score_data": 0.0,
-        "score_data_loc": 0.153,
+        "score_data_loc": 0.067,
         "score_loc": 0.133
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-10.07856,15.107436].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-10.07856,15.107436].json
@@ -1351,7 +1351,7 @@
         "rank_data_loc": "1",
         "rank_loc": "Not Displayed",
         "score_data": 1.0,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.634,
         "score_loc": 0.269
       },
       {
@@ -1363,7 +1363,7 @@
         "rank_data_loc": "2",
         "rank_loc": "2",
         "score_data": 1.0,
-        "score_data_loc": 0.931,
+        "score_data_loc": 0.591,
         "score_loc": 0.181
       },
       {
@@ -1375,7 +1375,7 @@
         "rank_data_loc": "3",
         "rank_loc": "7",
         "score_data": 0.738,
-        "score_data_loc": 0.621,
+        "score_data_loc": 0.394,
         "score_loc": 0.05
       },
       {
@@ -1387,7 +1387,7 @@
         "rank_data_loc": "4",
         "rank_loc": "5",
         "score_data": 0.681,
-        "score_data_loc": 0.616,
+        "score_data_loc": 0.391,
         "score_loc": 0.1
       },
       {
@@ -1399,7 +1399,7 @@
         "rank_data_loc": "5",
         "rank_loc": "8",
         "score_data": 0.681,
-        "score_data_loc": 0.556,
+        "score_data_loc": 0.353,
         "score_loc": 0.025
       },
       {
@@ -1411,7 +1411,7 @@
         "rank_data_loc": "6",
         "rank_loc": "6",
         "score_data": 0.5,
-        "score_data_loc": 0.448,
+        "score_data_loc": 0.284,
         "score_loc": 0.069
       },
       {
@@ -1423,7 +1423,7 @@
         "rank_data_loc": "7",
         "rank_loc": "9",
         "score_data": 0.433,
-        "score_data_loc": 0.361,
+        "score_data_loc": 0.229,
         "score_loc": 0.025
       },
       {
@@ -1435,7 +1435,7 @@
         "rank_data_loc": "8",
         "rank_loc": "3",
         "score_data": 1.0,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.144
       },
       {
@@ -1447,7 +1447,7 @@
         "rank_data_loc": "9",
         "rank_loc": "4",
         "score_data": 0.681,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.138
       },
       {
@@ -1459,7 +1459,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.738,
-        "score_data_loc": 0.724,
+        "score_data_loc": 0.459,
         "score_loc": 0.181
       },
       {
@@ -1471,7 +1471,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "1",
         "score_data": 0.433,
-        "score_data_loc": 0.553,
+        "score_data_loc": 0.351,
         "score_loc": 0.269
       },
       {
@@ -1483,7 +1483,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.433,
-        "score_data_loc": 0.396,
+        "score_data_loc": 0.251,
         "score_loc": 0.069
       },
       {
@@ -1495,7 +1495,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.308,
-        "score_data_loc": 0.322,
+        "score_data_loc": 0.204,
         "score_loc": 0.1
       },
       {
@@ -1507,7 +1507,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.738,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.144
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-10.950086,17.573093].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-10.950086,17.573093].json
@@ -1107,7 +1107,7 @@
         "rank_data_loc": "1",
         "rank_loc": 1,
         "score_data": 1.0,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.7,
         "score_loc": 0.4
       },
       {
@@ -1119,7 +1119,7 @@
         "rank_data_loc": "2",
         "rank_loc": 2,
         "score_data": 1.0,
-        "score_data_loc": 0.791,
+        "score_data_loc": 0.553,
         "score_loc": 0.107
       },
       {
@@ -1131,7 +1131,7 @@
         "rank_data_loc": "3",
         "rank_loc": 3,
         "score_data": 1.0,
-        "score_data_loc": 0.786,
+        "score_data_loc": 0.55,
         "score_loc": 0.1
       },
       {
@@ -1143,7 +1143,7 @@
         "rank_data_loc": "4",
         "rank_loc": 10,
         "score_data": 1.0,
-        "score_data_loc": 0.735,
+        "score_data_loc": 0.514,
         "score_loc": 0.029
       },
       {
@@ -1155,7 +1155,7 @@
         "rank_data_loc": "5",
         "rank_loc": 9,
         "score_data": 0.903,
-        "score_data_loc": 0.676,
+        "score_data_loc": 0.473,
         "score_loc": 0.043
       },
       {
@@ -1167,7 +1167,7 @@
         "rank_data_loc": "6",
         "rank_loc": 5,
         "score_data": 0.673,
-        "score_data_loc": 0.532,
+        "score_data_loc": 0.372,
         "score_loc": 0.071
       },
       {
@@ -1179,7 +1179,7 @@
         "rank_data_loc": "7",
         "rank_loc": 8,
         "score_data": 0.673,
-        "score_data_loc": 0.511,
+        "score_data_loc": 0.358,
         "score_loc": 0.043
       },
       {
@@ -1191,7 +1191,7 @@
         "rank_data_loc": "8",
         "rank_loc": 11,
         "score_data": 0.629,
-        "score_data_loc": 0.46,
+        "score_data_loc": 0.322,
         "score_loc": 0.014
       },
       {
@@ -1203,7 +1203,7 @@
         "rank_data_loc": "9",
         "rank_loc": 7,
         "score_data": 0.516,
-        "score_data_loc": 0.399,
+        "score_data_loc": 0.28,
         "score_loc": 0.043
       },
       {
@@ -1215,7 +1215,7 @@
         "rank_data_loc": "10",
         "rank_loc": 4,
         "score_data": 0.383,
-        "score_data_loc": 0.34,
+        "score_data_loc": 0.238,
         "score_loc": 0.093
       },
       {

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-19.13333,145.5125].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-19.13333,145.5125].json
@@ -1931,7 +1931,7 @@
         "rank_data_loc": "1",
         "rank_loc": "Not Displayed",
         "score_data": 0.919,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.523,
         "score_loc": 0.126
       },
       {
@@ -1943,7 +1943,7 @@
         "rank_data_loc": "2",
         "rank_loc": "Not Displayed",
         "score_data": 0.919,
-        "score_data_loc": 0.917,
+        "score_data_loc": 0.479,
         "score_loc": 0.039
       },
       {
@@ -1955,7 +1955,7 @@
         "rank_data_loc": "3",
         "rank_loc": "11",
         "score_data": 0.919,
-        "score_data_loc": 0.887,
+        "score_data_loc": 0.463,
         "score_loc": 0.008
       },
       {
@@ -1967,7 +1967,7 @@
         "rank_data_loc": "4",
         "rank_loc": "Not Displayed",
         "score_data": 0.821,
-        "score_data_loc": 0.876,
+        "score_data_loc": 0.457,
         "score_loc": 0.094
       },
       {
@@ -1979,7 +1979,7 @@
         "rank_data_loc": "5",
         "rank_loc": "5",
         "score_data": 0.753,
-        "score_data_loc": 0.804,
+        "score_data_loc": 0.42,
         "score_loc": 0.087
       },
       {
@@ -1991,7 +1991,7 @@
         "rank_data_loc": "6",
         "rank_loc": "Not Displayed",
         "score_data": 0.753,
-        "score_data_loc": 0.756,
+        "score_data_loc": 0.395,
         "score_loc": 0.037
       },
       {
@@ -2003,7 +2003,7 @@
         "rank_data_loc": "7",
         "rank_loc": "2",
         "score_data": 0.657,
-        "score_data_loc": 0.744,
+        "score_data_loc": 0.389,
         "score_loc": 0.12
       },
       {
@@ -2015,7 +2015,7 @@
         "rank_data_loc": "8",
         "rank_loc": "6",
         "score_data": 0.722,
-        "score_data_loc": 0.742,
+        "score_data_loc": 0.388,
         "score_loc": 0.054
       },
       {
@@ -2027,7 +2027,7 @@
         "rank_data_loc": "9",
         "rank_loc": "12",
         "score_data": 0.757,
-        "score_data_loc": 0.732,
+        "score_data_loc": 0.382,
         "score_loc": 0.008
       },
       {
@@ -2039,7 +2039,7 @@
         "rank_data_loc": "10",
         "rank_loc": "10",
         "score_data": 0.722,
-        "score_data_loc": 0.706,
+        "score_data_loc": 0.369,
         "score_loc": 0.016
       },
       {
@@ -2051,7 +2051,7 @@
         "rank_data_loc": "11",
         "rank_loc": "9",
         "score_data": 0.625,
-        "score_data_loc": 0.624,
+        "score_data_loc": 0.326,
         "score_loc": 0.027
       },
       {
@@ -2063,7 +2063,7 @@
         "rank_data_loc": "12",
         "rank_loc": "4",
         "score_data": 0.413,
-        "score_data_loc": 0.479,
+        "score_data_loc": 0.25,
         "score_loc": 0.088
       },
       {
@@ -2075,7 +2075,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.919,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.523,
         "score_loc": 0.126
       },
       {
@@ -2087,7 +2087,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "1",
         "score_data": 0.625,
-        "score_data_loc": 0.719,
+        "score_data_loc": 0.376,
         "score_loc": 0.126
       },
       {
@@ -2099,7 +2099,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.622,
-        "score_data_loc": 0.711,
+        "score_data_loc": 0.371,
         "score_loc": 0.12
       },
       {
@@ -2111,7 +2111,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.625,
-        "score_data_loc": 0.681,
+        "score_data_loc": 0.356,
         "score_loc": 0.087
       },
       {
@@ -2123,7 +2123,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "3",
         "score_data": 0.557,
-        "score_data_loc": 0.624,
+        "score_data_loc": 0.326,
         "score_loc": 0.094
       },
       {
@@ -2135,7 +2135,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "8",
         "score_data": 0.587,
-        "score_data_loc": 0.597,
+        "score_data_loc": 0.312,
         "score_loc": 0.037
       },
       {
@@ -2147,7 +2147,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "7",
         "score_data": 0.557,
-        "score_data_loc": 0.571,
+        "score_data_loc": 0.298,
         "score_loc": 0.039
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-2.06972,37.29].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-2.06972,37.29].json
@@ -1431,7 +1431,7 @@
         "rank_data_loc": "1",
         "rank_loc": "1",
         "score_data": 0.649,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.378,
         "score_loc": 0.107
       },
       {
@@ -1443,7 +1443,7 @@
         "rank_data_loc": "2",
         "rank_loc": "4",
         "score_data": 0.691,
-        "score_data_loc": 0.987,
+        "score_data_loc": 0.373,
         "score_loc": 0.055
       },
       {
@@ -1455,7 +1455,7 @@
         "rank_data_loc": "3",
         "rank_loc": "5",
         "score_data": 0.683,
-        "score_data_loc": 0.966,
+        "score_data_loc": 0.365,
         "score_loc": 0.047
       },
       {
@@ -1467,7 +1467,7 @@
         "rank_data_loc": "4",
         "rank_loc": "3",
         "score_data": 0.653,
-        "score_data_loc": 0.956,
+        "score_data_loc": 0.361,
         "score_loc": 0.07
       },
       {
@@ -1479,7 +1479,7 @@
         "rank_data_loc": "5",
         "rank_loc": "12",
         "score_data": 0.691,
-        "score_data_loc": 0.935,
+        "score_data_loc": 0.353,
         "score_loc": 0.015
       },
       {
@@ -1491,7 +1491,7 @@
         "rank_data_loc": "6",
         "rank_loc": "9",
         "score_data": 0.666,
-        "score_data_loc": 0.924,
+        "score_data_loc": 0.349,
         "score_loc": 0.032
       },
       {
@@ -1503,7 +1503,7 @@
         "rank_data_loc": "7",
         "rank_loc": "11",
         "score_data": 0.666,
-        "score_data_loc": 0.906,
+        "score_data_loc": 0.343,
         "score_loc": 0.019
       },
       {
@@ -1515,7 +1515,7 @@
         "rank_data_loc": "8",
         "rank_loc": "2",
         "score_data": 0.58,
-        "score_data_loc": 0.869,
+        "score_data_loc": 0.329,
         "score_loc": 0.077
       },
       {
@@ -1527,7 +1527,7 @@
         "rank_data_loc": "9",
         "rank_loc": "Not Displayed",
         "score_data": 0.617,
-        "score_data_loc": 0.861,
+        "score_data_loc": 0.326,
         "score_loc": 0.034
       },
       {
@@ -1539,7 +1539,7 @@
         "rank_data_loc": "10",
         "rank_loc": "6",
         "score_data": 0.602,
-        "score_data_loc": 0.85,
+        "score_data_loc": 0.321,
         "score_loc": 0.04
       },
       {
@@ -1551,7 +1551,7 @@
         "rank_data_loc": "11",
         "rank_loc": "7",
         "score_data": 0.492,
-        "score_data_loc": 0.698,
+        "score_data_loc": 0.264,
         "score_loc": 0.036
       },
       {
@@ -1563,7 +1563,7 @@
         "rank_data_loc": "12",
         "rank_loc": "10",
         "score_data": 0.326,
-        "score_data_loc": 0.469,
+        "score_data_loc": 0.177,
         "score_loc": 0.028
       },
       {
@@ -1575,7 +1575,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "8",
         "score_data": 0.58,
-        "score_data_loc": 0.812,
+        "score_data_loc": 0.307,
         "score_loc": 0.034
       },
       {
@@ -1587,7 +1587,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.123,
-        "score_data_loc": 0.21,
+        "score_data_loc": 0.079,
         "score_loc": 0.036
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-24.53333,33.36667].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[-24.53333,33.36667].json
@@ -1231,7 +1231,7 @@
         "rank_data_loc": "1",
         "rank_loc": "2",
         "score_data": 0.9,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.539,
         "score_loc": 0.178
       },
       {
@@ -1243,7 +1243,7 @@
         "rank_data_loc": "2",
         "rank_loc": "4",
         "score_data": 0.9,
-        "score_data_loc": 0.953,
+        "score_data_loc": 0.514,
         "score_loc": 0.127
       },
       {
@@ -1255,7 +1255,7 @@
         "rank_data_loc": "3",
         "rank_loc": "5",
         "score_data": 0.9,
-        "score_data_loc": 0.937,
+        "score_data_loc": 0.505,
         "score_loc": 0.109
       },
       {
@@ -1267,7 +1267,7 @@
         "rank_data_loc": "4",
         "rank_loc": "6",
         "score_data": 0.9,
-        "score_data_loc": 0.928,
+        "score_data_loc": 0.5,
         "score_loc": 0.1
       },
       {
@@ -1279,7 +1279,7 @@
         "rank_data_loc": "5",
         "rank_loc": "7",
         "score_data": 0.9,
-        "score_data_loc": 0.903,
+        "score_data_loc": 0.487,
         "score_loc": 0.073
       },
       {
@@ -1291,7 +1291,7 @@
         "rank_data_loc": "6",
         "rank_loc": "Not Displayed",
         "score_data": 0.813,
-        "score_data_loc": 0.873,
+        "score_data_loc": 0.47,
         "score_loc": 0.127
       },
       {
@@ -1303,7 +1303,7 @@
         "rank_data_loc": "7",
         "rank_loc": "1",
         "score_data": 0.756,
-        "score_data_loc": 0.87,
+        "score_data_loc": 0.469,
         "score_loc": 0.182
       },
       {
@@ -1315,7 +1315,7 @@
         "rank_data_loc": "8",
         "rank_loc": "8",
         "score_data": 0.576,
-        "score_data_loc": 0.585,
+        "score_data_loc": 0.315,
         "score_loc": 0.055
       },
       {
@@ -1327,7 +1327,7 @@
         "rank_data_loc": "9",
         "rank_loc": "9",
         "score_data": 0.576,
-        "score_data_loc": 0.568,
+        "score_data_loc": 0.306,
         "score_loc": 0.036
       },
       {
@@ -1339,7 +1339,7 @@
         "rank_data_loc": "10",
         "rank_loc": "10",
         "score_data": 0.244,
-        "score_data_loc": 0.239,
+        "score_data_loc": 0.129,
         "score_loc": 0.013
       },
       {
@@ -1351,7 +1351,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
         "score_data": 0.576,
-        "score_data_loc": 0.699,
+        "score_data_loc": 0.377,
         "score_loc": 0.178
       },
       {
@@ -1363,7 +1363,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "3",
         "score_data": 0.244,
-        "score_data_loc": 0.345,
+        "score_data_loc": 0.186,
         "score_loc": 0.127
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[15.73333,120.31667].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[15.73333,120.31667].json
@@ -1199,7 +1199,7 @@
         "rank_data_loc": "1",
         "rank_loc": 1,
         "score_data": 0.475,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.323,
         "score_loc": 0.17
       },
       {
@@ -1211,7 +1211,7 @@
         "rank_data_loc": "2",
         "rank_loc": 2,
         "score_data": 0.515,
-        "score_data_loc": 0.983,
+        "score_data_loc": 0.317,
         "score_loc": 0.12
       },
       {
@@ -1223,7 +1223,7 @@
         "rank_data_loc": "3",
         "rank_loc": 4,
         "score_data": 0.515,
-        "score_data_loc": 0.983,
+        "score_data_loc": 0.317,
         "score_loc": 0.12
       },
       {
@@ -1235,7 +1235,7 @@
         "rank_data_loc": "4",
         "rank_loc": 5,
         "score_data": 0.515,
-        "score_data_loc": 0.952,
+        "score_data_loc": 0.307,
         "score_loc": 0.1
       },
       {
@@ -1247,7 +1247,7 @@
         "rank_data_loc": "5",
         "rank_loc": 10,
         "score_data": 0.566,
-        "score_data_loc": 0.908,
+        "score_data_loc": 0.293,
         "score_loc": 0.02
       },
       {
@@ -1259,7 +1259,7 @@
         "rank_data_loc": "6",
         "rank_loc": 7,
         "score_data": 0.464,
-        "score_data_loc": 0.827,
+        "score_data_loc": 0.267,
         "score_loc": 0.07
       },
       {
@@ -1271,7 +1271,7 @@
         "rank_data_loc": "7",
         "rank_loc": 3,
         "score_data": 0.402,
-        "score_data_loc": 0.809,
+        "score_data_loc": 0.261,
         "score_loc": 0.12
       },
       {
@@ -1283,7 +1283,7 @@
         "rank_data_loc": "8",
         "rank_loc": 9,
         "score_data": 0.451,
-        "score_data_loc": 0.745,
+        "score_data_loc": 0.24,
         "score_loc": 0.03
       },
       {
@@ -1295,7 +1295,7 @@
         "rank_data_loc": "9",
         "rank_loc": 12,
         "score_data": 0.337,
-        "score_data_loc": 0.538,
+        "score_data_loc": 0.174,
         "score_loc": 0.01
       },
       {
@@ -1307,7 +1307,7 @@
         "rank_data_loc": "10",
         "rank_loc": 8,
         "score_data": 0.208,
-        "score_data_loc": 0.383,
+        "score_data_loc": 0.124,
         "score_loc": 0.04
       },
       {
@@ -1319,7 +1319,7 @@
         "rank_data_loc": "11",
         "rank_loc": 6,
         "score_data": 0.157,
-        "score_data_loc": 0.367,
+        "score_data_loc": 0.118,
         "score_loc": 0.08
       },
       {
@@ -1331,7 +1331,7 @@
         "rank_data_loc": "12",
         "rank_loc": 11,
         "score_data": 0.465,
-        "score_data_loc": 0.003,
+        "score_data_loc": 0.001,
         "score_loc": 0.02
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[30.38333,35.53333].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[30.38333,35.53333].json
@@ -699,7 +699,7 @@
         "rank_data_loc": "1",
         "rank_loc": 3,
         "score_data": 1.0,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.564,
         "score_loc": 0.128
       },
       {
@@ -711,7 +711,7 @@
         "rank_data_loc": "2",
         "rank_loc": 7,
         "score_data": 1.0,
-        "score_data_loc": 0.937,
+        "score_data_loc": 0.528,
         "score_loc": 0.057
       },
       {
@@ -723,7 +723,7 @@
         "rank_data_loc": "3",
         "rank_loc": 1,
         "score_data": 0.0,
-        "score_data_loc": 0.29,
+        "score_data_loc": 0.164,
         "score_loc": 0.327
       },
       {
@@ -735,7 +735,7 @@
         "rank_data_loc": "4",
         "rank_loc": 4,
         "score_data": 0.0,
-        "score_data_loc": 0.065,
+        "score_data_loc": 0.036,
         "score_loc": 0.073
       },
       {
@@ -747,7 +747,7 @@
         "rank_data_loc": "5",
         "rank_loc": 5,
         "score_data": 0.0,
-        "score_data_loc": 0.063,
+        "score_data_loc": 0.036,
         "score_loc": 0.071
       },
       {
@@ -759,7 +759,7 @@
         "rank_data_loc": "6",
         "rank_loc": 6,
         "score_data": 0.0,
-        "score_data_loc": 0.05,
+        "score_data_loc": 0.028,
         "score_loc": 0.057
       },
       {
@@ -771,7 +771,7 @@
         "rank_data_loc": "7",
         "rank_loc": 2,
         "score_data": 0.0,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.286
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[32.11667,20.08333].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[32.11667,20.08333].json
@@ -599,7 +599,7 @@
         "rank_data_loc": "1",
         "rank_loc": 4,
         "score_data": 0.403,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.302,
         "score_loc": 0.2
       },
       {
@@ -611,7 +611,7 @@
         "rank_data_loc": "2",
         "rank_loc": 5,
         "score_data": 0.499,
-        "score_data_loc": 0.91,
+        "score_data_loc": 0.275,
         "score_loc": 0.05
       },
       {
@@ -623,7 +623,7 @@
         "rank_data_loc": "3",
         "rank_loc": 2,
         "score_data": 0.349,
-        "score_data_loc": 0.909,
+        "score_data_loc": 0.274,
         "score_loc": 0.2
       },
       {
@@ -635,7 +635,7 @@
         "rank_data_loc": "4",
         "rank_loc": 1,
         "score_data": 0.183,
-        "score_data_loc": 0.8,
+        "score_data_loc": 0.241,
         "score_loc": 0.3
       },
       {
@@ -647,7 +647,7 @@
         "rank_data_loc": "5",
         "rank_loc": 3,
         "score_data": 0.234,
-        "score_data_loc": 0.719,
+        "score_data_loc": 0.217,
         "score_loc": 0.2
       },
       {
@@ -659,7 +659,7 @@
         "rank_data_loc": "6",
         "rank_loc": 6,
         "score_data": 0.233,
-        "score_data_loc": 0.003,
+        "score_data_loc": 0.001,
         "score_loc": 0.05
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[34.5,69.16667].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[34.5,69.16667].json
@@ -399,7 +399,7 @@
         "rank_data_loc": "1",
         "rank_loc": 1,
         "score_data": 1.0,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.763,
         "score_loc": 0.526
       },
       {
@@ -411,7 +411,7 @@
         "rank_data_loc": "2",
         "rank_loc": 2,
         "score_data": 0.437,
-        "score_data_loc": 0.524,
+        "score_data_loc": 0.4,
         "score_loc": 0.363
       },
       {
@@ -423,7 +423,7 @@
         "rank_data_loc": "3",
         "rank_loc": 4,
         "score_data": 0.437,
-        "score_data_loc": 0.295,
+        "score_data_loc": 0.225,
         "score_loc": 0.012
       },
       {

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[37.33333,-5.4].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[37.33333,-5.4].json
@@ -1275,7 +1275,7 @@
         "rank_data_loc": "1",
         "rank_loc": "Not Displayed",
         "score_data": 0.836,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.552,
         "score_loc": 0.268
       },
       {
@@ -1287,7 +1287,7 @@
         "rank_data_loc": "2",
         "rank_loc": "1",
         "score_data": 0.699,
-        "score_data_loc": 0.885,
+        "score_data_loc": 0.489,
         "score_loc": 0.278
       },
       {
@@ -1299,7 +1299,7 @@
         "rank_data_loc": "3",
         "rank_loc": "Not Displayed",
         "score_data": 0.894,
-        "score_data_loc": 0.848,
+        "score_data_loc": 0.468,
         "score_loc": 0.043
       },
       {
@@ -1311,7 +1311,7 @@
         "rank_data_loc": "4",
         "rank_loc": "3",
         "score_data": 0.699,
-        "score_data_loc": 0.704,
+        "score_data_loc": 0.389,
         "score_loc": 0.078
       },
       {
@@ -1323,7 +1323,7 @@
         "rank_data_loc": "5",
         "rank_loc": "4",
         "score_data": 0.699,
-        "score_data_loc": 0.692,
+        "score_data_loc": 0.382,
         "score_loc": 0.065
       },
       {
@@ -1335,7 +1335,7 @@
         "rank_data_loc": "6",
         "rank_loc": "5",
         "score_data": 0.625,
-        "score_data_loc": 0.618,
+        "score_data_loc": 0.341,
         "score_loc": 0.057
       },
       {
@@ -1347,7 +1347,7 @@
         "rank_data_loc": "7",
         "rank_loc": "8",
         "score_data": 0.625,
-        "score_data_loc": 0.612,
+        "score_data_loc": 0.338,
         "score_loc": 0.05
       },
       {
@@ -1359,7 +1359,7 @@
         "rank_data_loc": "8",
         "rank_loc": "6",
         "score_data": 0.412,
-        "score_data_loc": 0.425,
+        "score_data_loc": 0.235,
         "score_loc": 0.057
       },
       {
@@ -1371,7 +1371,7 @@
         "rank_data_loc": "9",
         "rank_loc": "10",
         "score_data": 0.421,
-        "score_data_loc": 0.407,
+        "score_data_loc": 0.225,
         "score_loc": 0.029
       },
       {
@@ -1383,7 +1383,7 @@
         "rank_data_loc": "10",
         "rank_loc": "7",
         "score_data": 0.49,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.057
       },
       {
@@ -1395,7 +1395,7 @@
         "rank_data_loc": "11",
         "rank_loc": "11",
         "score_data": 0.711,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.018
       },
       {
@@ -1407,7 +1407,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "9",
         "score_data": 0.864,
-        "score_data_loc": 0.821,
+        "score_data_loc": 0.453,
         "score_loc": 0.043
       },
       {
@@ -1419,7 +1419,7 @@
         "rank_data_loc": "Not Displayed",
         "rank_loc": "2",
         "score_data": 0.525,
-        "score_data_loc": 0.718,
+        "score_data_loc": 0.397,
         "score_loc": 0.268
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[48.71667,126.13333].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[48.71667,126.13333].json
@@ -731,7 +731,7 @@
         "rank_data_loc": "1",
         "rank_loc": 3,
         "score_data": 0.431,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.298,
         "score_loc": 0.165
       },
       {
@@ -743,7 +743,7 @@
         "rank_data_loc": "2",
         "rank_loc": 4,
         "score_data": 0.385,
-        "score_data_loc": 0.83,
+        "score_data_loc": 0.247,
         "score_loc": 0.11
       },
       {
@@ -755,7 +755,7 @@
         "rank_data_loc": "3",
         "rank_loc": 5,
         "score_data": 0.431,
-        "score_data_loc": 0.815,
+        "score_data_loc": 0.243,
         "score_loc": 0.055
       },
       {
@@ -767,7 +767,7 @@
         "rank_data_loc": "4",
         "rank_loc": 7,
         "score_data": 0.385,
-        "score_data_loc": 0.738,
+        "score_data_loc": 0.22,
         "score_loc": 0.055
       },
       {
@@ -779,7 +779,7 @@
         "rank_data_loc": "5",
         "rank_loc": 1,
         "score_data": 0.068,
-        "score_data_loc": 0.729,
+        "score_data_loc": 0.217,
         "score_loc": 0.366
       },
       {
@@ -791,7 +791,7 @@
         "rank_data_loc": "6",
         "rank_loc": 2,
         "score_data": 0.068,
-        "score_data_loc": 0.44,
+        "score_data_loc": 0.131,
         "score_loc": 0.194
       },
       {
@@ -803,7 +803,7 @@
         "rank_data_loc": "7",
         "rank_loc": 6,
         "score_data": 0.068,
-        "score_data_loc": 0.207,
+        "score_data_loc": 0.062,
         "score_loc": 0.055
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[7.3318,-1.4631].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[7.3318,-1.4631].json
@@ -1207,7 +1207,7 @@
         "rank_data_loc": "1",
         "rank_loc": 3,
         "score_data": 1.0,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.541,
         "score_loc": 0.083
       },
       {
@@ -1219,7 +1219,7 @@
         "rank_data_loc": "2",
         "rank_loc": 4,
         "score_data": 1.0,
-        "score_data_loc": 0.998,
+        "score_data_loc": 0.54,
         "score_loc": 0.08
       },
       {
@@ -1231,7 +1231,7 @@
         "rank_data_loc": "3",
         "rank_loc": 2,
         "score_data": 0.566,
-        "score_data_loc": 0.629,
+        "score_data_loc": 0.341,
         "score_loc": 0.116
       },
       {
@@ -1243,7 +1243,7 @@
         "rank_data_loc": "4",
         "rank_loc": 8,
         "score_data": 0.566,
-        "score_data_loc": 0.564,
+        "score_data_loc": 0.305,
         "score_loc": 0.045
       },
       {
@@ -1255,7 +1255,7 @@
         "rank_data_loc": "5",
         "rank_loc": 9,
         "score_data": 0.566,
-        "score_data_loc": 0.562,
+        "score_data_loc": 0.304,
         "score_loc": 0.042
       },
       {
@@ -1267,7 +1267,7 @@
         "rank_data_loc": "6",
         "rank_loc": 6,
         "score_data": 0.451,
-        "score_data_loc": 0.474,
+        "score_data_loc": 0.257,
         "score_loc": 0.062
       },
       {
@@ -1279,7 +1279,7 @@
         "rank_data_loc": "7",
         "rank_loc": 1,
         "score_data": 0.36,
-        "score_data_loc": 0.447,
+        "score_data_loc": 0.242,
         "score_loc": 0.124
       },
       {
@@ -1291,7 +1291,7 @@
         "rank_data_loc": "8",
         "rank_loc": 10,
         "score_data": 0.451,
-        "score_data_loc": 0.433,
+        "score_data_loc": 0.235,
         "score_loc": 0.018
       },
       {
@@ -1303,7 +1303,7 @@
         "rank_data_loc": "9",
         "rank_loc": 12,
         "score_data": 0.451,
-        "score_data_loc": 0.419,
+        "score_data_loc": 0.227,
         "score_loc": 0.002
       },
       {
@@ -1315,7 +1315,7 @@
         "rank_data_loc": "10",
         "rank_loc": 5,
         "score_data": 0.36,
-        "score_data_loc": 0.399,
+        "score_data_loc": 0.216,
         "score_loc": 0.072
       },
       {
@@ -1327,7 +1327,7 @@
         "rank_data_loc": "11",
         "rank_loc": 11,
         "score_data": 0.36,
-        "score_data_loc": 0.349,
+        "score_data_loc": 0.189,
         "score_loc": 0.018
       },
       {
@@ -1339,7 +1339,7 @@
         "rank_data_loc": "12",
         "rank_loc": 7,
         "score_data": 0.451,
-        "score_data_loc": 0.002,
+        "score_data_loc": 0.001,
         "score_loc": 0.05
       }
     ]

--- a/soil_id/tests/global/__snapshots__/test_global/test_soil_location[8.48333,76.95].json
+++ b/soil_id/tests/global/__snapshots__/test_global/test_soil_location[8.48333,76.95].json
@@ -1099,7 +1099,7 @@
         "rank_data_loc": "1",
         "rank_loc": 4,
         "score_data": 0.524,
-        "score_data_loc": 1.0,
+        "score_data_loc": 0.318,
         "score_loc": 0.112
       },
       {
@@ -1111,7 +1111,7 @@
         "rank_data_loc": "2",
         "rank_loc": 8,
         "score_data": 0.568,
-        "score_data_loc": 0.98,
+        "score_data_loc": 0.312,
         "score_loc": 0.055
       },
       {
@@ -1123,7 +1123,7 @@
         "rank_data_loc": "3",
         "rank_loc": 6,
         "score_data": 0.484,
-        "score_data_loc": 0.903,
+        "score_data_loc": 0.287,
         "score_loc": 0.089
       },
       {
@@ -1135,7 +1135,7 @@
         "rank_data_loc": "4",
         "rank_loc": 2,
         "score_data": 0.401,
-        "score_data_loc": 0.875,
+        "score_data_loc": 0.278,
         "score_loc": 0.155
       },
       {
@@ -1147,7 +1147,7 @@
         "rank_data_loc": "5",
         "rank_loc": 7,
         "score_data": 0.444,
-        "score_data_loc": 0.786,
+        "score_data_loc": 0.25,
         "score_loc": 0.055
       },
       {
@@ -1159,7 +1159,7 @@
         "rank_data_loc": "6",
         "rank_loc": 3,
         "score_data": 0.349,
-        "score_data_loc": 0.76,
+        "score_data_loc": 0.241,
         "score_loc": 0.134
       },
       {
@@ -1171,7 +1171,7 @@
         "rank_data_loc": "7",
         "rank_loc": 9,
         "score_data": 0.427,
-        "score_data_loc": 0.759,
+        "score_data_loc": 0.241,
         "score_loc": 0.055
       },
       {
@@ -1183,7 +1183,7 @@
         "rank_data_loc": "8",
         "rank_loc": 10,
         "score_data": 0.432,
-        "score_data_loc": 0.75,
+        "score_data_loc": 0.238,
         "score_loc": 0.045
       },
       {
@@ -1195,7 +1195,7 @@
         "rank_data_loc": "9",
         "rank_loc": 5,
         "score_data": 0.238,
-        "score_data_loc": 0.549,
+        "score_data_loc": 0.175,
         "score_loc": 0.111
       },
       {
@@ -1207,7 +1207,7 @@
         "rank_data_loc": "10",
         "rank_loc": 1,
         "score_data": 0.083,
-        "score_data_loc": 0.392,
+        "score_data_loc": 0.125,
         "score_loc": 0.166
       },
       {
@@ -1219,7 +1219,7 @@
         "rank_data_loc": "11",
         "rank_loc": 11,
         "score_data": 0.432,
-        "score_data_loc": 0.003,
+        "score_data_loc": 0.001,
         "score_loc": 0.022
       }
     ]

--- a/soil_id/tests/us/__snapshots__/test_us/test_soil_location[33.81246789,-101.9733687].json
+++ b/soil_id/tests/us/__snapshots__/test_us/test_soil_location[33.81246789,-101.9733687].json
@@ -665,8 +665,8 @@
         "rank_data": "8",
         "rank_data_loc": "1",
         "rank_loc": "1",
-        "score_data": 0.429,
-        "score_data_loc": 0.452,
+        "score_data": 0.427,
+        "score_data_loc": 0.451,
         "score_loc": 0.474
       },
       {
@@ -677,21 +677,9 @@
         "rank_data": "1",
         "rank_data_loc": "2",
         "rank_loc": "Not Displayed",
-        "score_data": 0.591,
-        "score_data_loc": 0.422,
+        "score_data": 0.593,
+        "score_data_loc": 0.423,
         "score_loc": 0.253
-      },
-      {
-        "component": "Friona",
-        "componentData": "Data Complete",
-        "componentID": 25623214,
-        "name": "Friona",
-        "rank_data": "2",
-        "rank_data_loc": "3",
-        "rank_loc": "7",
-        "score_data": 0.571,
-        "score_data_loc": 0.293,
-        "score_loc": 0.014
       },
       {
         "component": "Olton",
@@ -699,11 +687,23 @@
         "componentID": 25623299,
         "name": "Olton",
         "rank_data": "7",
-        "rank_data_loc": "4",
+        "rank_data_loc": "3",
         "rank_loc": "3",
-        "score_data": 0.457,
-        "score_data_loc": 0.292,
+        "score_data": 0.46,
+        "score_data_loc": 0.293,
         "score_loc": 0.126
+      },
+      {
+        "component": "Friona",
+        "componentData": "Data Complete",
+        "componentID": 25623214,
+        "name": "Friona",
+        "rank_data": "2",
+        "rank_data_loc": "4",
+        "rank_loc": "7",
+        "score_data": 0.57,
+        "score_data_loc": 0.292,
+        "score_loc": 0.014
       },
       {
         "component": "Amarillo",
@@ -713,8 +713,8 @@
         "rank_data": "3",
         "rank_data_loc": "5",
         "rank_loc": "8",
-        "score_data": 0.554,
-        "score_data_loc": 0.283,
+        "score_data": 0.553,
+        "score_data_loc": 0.282,
         "score_loc": 0.011
       },
       {
@@ -725,8 +725,8 @@
         "rank_data": "5",
         "rank_data_loc": "6",
         "rank_loc": "5",
-        "score_data": 0.531,
-        "score_data_loc": 0.28,
+        "score_data": 0.533,
+        "score_data_loc": 0.281,
         "score_loc": 0.03
       },
       {
@@ -737,8 +737,8 @@
         "rank_data": "4",
         "rank_data_loc": "7",
         "rank_loc": "9",
-        "score_data": 0.536,
-        "score_data_loc": 0.274,
+        "score_data": 0.539,
+        "score_data_loc": 0.275,
         "score_loc": 0.011
       },
       {
@@ -749,7 +749,7 @@
         "rank_data": "6",
         "rank_data_loc": "8",
         "rank_loc": "6",
-        "score_data": 0.493,
+        "score_data": 0.492,
         "score_data_loc": 0.257,
         "score_loc": 0.021
       },
@@ -761,8 +761,8 @@
         "rank_data": "9",
         "rank_data_loc": "9",
         "rank_loc": "4",
-        "score_data": 0.412,
-        "score_data_loc": 0.236,
+        "score_data": 0.411,
+        "score_data_loc": 0.235,
         "score_loc": 0.059
       },
       {
@@ -773,8 +773,8 @@
         "rank_data": "Not Displayed",
         "rank_data_loc": "Not Displayed",
         "rank_loc": "2",
-        "score_data": 0.578,
-        "score_data_loc": 0.416,
+        "score_data": 0.576,
+        "score_data_loc": 0.414,
         "score_loc": 0.253
       },
       {
@@ -785,8 +785,8 @@
         "rank_data": "Not Displayed",
         "rank_data_loc": "Not Displayed",
         "rank_loc": "Not Displayed",
-        "score_data": 0.443,
-        "score_data_loc": 0.232,
+        "score_data": 0.441,
+        "score_data_loc": 0.231,
         "score_loc": 0.021
       }
     ]

--- a/soil_id/tests/us/__snapshots__/test_us/test_soil_location[42.494912,-123.064531].json
+++ b/soil_id/tests/us/__snapshots__/test_us/test_soil_location[42.494912,-123.064531].json
@@ -606,11 +606,11 @@
         "componentData": "Data Complete",
         "componentID": 25443415,
         "name": "Ruch",
-        "rank_data": "4",
+        "rank_data": "3",
         "rank_data_loc": "1",
         "rank_loc": "1",
-        "score_data": 0.677,
-        "score_data_loc": 0.472,
+        "score_data": 0.671,
+        "score_data_loc": 0.469,
         "score_loc": 0.267
       },
       {
@@ -618,11 +618,11 @@
         "componentData": NaN,
         "componentID": 25443848,
         "name": "Josephine2",
-        "rank_data": "3",
+        "rank_data": "4",
         "rank_data_loc": "2",
         "rank_loc": "Not Displayed",
-        "score_data": 0.68,
-        "score_data_loc": 0.403,
+        "score_data": 0.664,
+        "score_data_loc": 0.395,
         "score_loc": 0.125
       },
       {
@@ -633,8 +633,8 @@
         "rank_data": "2",
         "rank_data_loc": "3",
         "rank_loc": "3",
-        "score_data": 0.72,
-        "score_data_loc": 0.395,
+        "score_data": 0.709,
+        "score_data_loc": 0.389,
         "score_loc": 0.069
       },
       {
@@ -645,8 +645,8 @@
         "rank_data": "1",
         "rank_data_loc": "4",
         "rank_loc": "9",
-        "score_data": 0.749,
-        "score_data_loc": 0.378,
+        "score_data": 0.746,
+        "score_data_loc": 0.376,
         "score_loc": 0.007
       },
       {
@@ -657,8 +657,8 @@
         "rank_data": "5",
         "rank_data_loc": "5",
         "rank_loc": "7",
-        "score_data": 0.623,
-        "score_data_loc": 0.324,
+        "score_data": 0.626,
+        "score_data_loc": 0.326,
         "score_loc": 0.025
       },
       {
@@ -669,8 +669,8 @@
         "rank_data": "6",
         "rank_data_loc": "6",
         "rank_loc": "8",
-        "score_data": 0.472,
-        "score_data_loc": 0.244,
+        "score_data": 0.473,
+        "score_data_loc": 0.245,
         "score_loc": 0.017
       },
       {
@@ -681,8 +681,8 @@
         "rank_data": "7",
         "rank_data_loc": "7",
         "rank_loc": "4",
-        "score_data": 0.402,
-        "score_data_loc": 0.226,
+        "score_data": 0.406,
+        "score_data_loc": 0.228,
         "score_loc": 0.05
       },
       {
@@ -693,8 +693,8 @@
         "rank_data": "9",
         "rank_data_loc": "8",
         "rank_loc": "5",
-        "score_data": 0.385,
-        "score_data_loc": 0.215,
+        "score_data": 0.388,
+        "score_data_loc": 0.217,
         "score_loc": 0.046
       },
       {
@@ -705,8 +705,8 @@
         "rank_data": "8",
         "rank_data_loc": "9",
         "rank_loc": "6",
-        "score_data": 0.387,
-        "score_data_loc": 0.206,
+        "score_data": 0.392,
+        "score_data_loc": 0.209,
         "score_loc": 0.025
       },
       {

--- a/soil_id/tests/us/__snapshots__/test_us/test_soil_location[43.06450312,-119.4596489].json
+++ b/soil_id/tests/us/__snapshots__/test_us/test_soil_location[43.06450312,-119.4596489].json
@@ -553,8 +553,8 @@
         "rank_data": "6",
         "rank_data_loc": "1",
         "rank_loc": 1,
-        "score_data": 0.616,
-        "score_data_loc": 0.442,
+        "score_data": 0.611,
+        "score_data_loc": 0.439,
         "score_loc": 0.267
       },
       {
@@ -565,7 +565,7 @@
         "rank_data": "2",
         "rank_data_loc": "2",
         "rank_loc": 2,
-        "score_data": 0.691,
+        "score_data": 0.69,
         "score_data_loc": 0.439,
         "score_loc": 0.187
       },
@@ -577,8 +577,8 @@
         "rank_data": "1",
         "rank_data_loc": "3",
         "rank_loc": 5,
-        "score_data": 0.697,
-        "score_data_loc": 0.405,
+        "score_data": 0.695,
+        "score_data_loc": 0.404,
         "score_loc": 0.113
       },
       {
@@ -589,8 +589,8 @@
         "rank_data": "5",
         "rank_data_loc": "4",
         "rank_loc": 4,
-        "score_data": 0.623,
-        "score_data_loc": 0.368,
+        "score_data": 0.621,
+        "score_data_loc": 0.367,
         "score_loc": 0.113
       },
       {
@@ -601,8 +601,8 @@
         "rank_data": "3",
         "rank_data_loc": "5",
         "rank_loc": 8,
-        "score_data": 0.661,
-        "score_data_loc": 0.354,
+        "score_data": 0.656,
+        "score_data_loc": 0.351,
         "score_loc": 0.046
       },
       {
@@ -613,7 +613,7 @@
         "rank_data": "4",
         "rank_data_loc": "6",
         "rank_loc": 7,
-        "score_data": 0.63,
+        "score_data": 0.629,
         "score_data_loc": 0.348,
         "score_loc": 0.067
       },
@@ -625,8 +625,8 @@
         "rank_data": "8",
         "rank_data_loc": "7",
         "rank_loc": 3,
-        "score_data": 0.581,
-        "score_data_loc": 0.347,
+        "score_data": 0.579,
+        "score_data_loc": 0.346,
         "score_loc": 0.113
       },
       {
@@ -637,8 +637,8 @@
         "rank_data": "7",
         "rank_data_loc": "8",
         "rank_loc": 9,
-        "score_data": 0.607,
-        "score_data_loc": 0.306,
+        "score_data": 0.602,
+        "score_data_loc": 0.304,
         "score_loc": 0.005
       },
       {


### PR DESCRIPTION
Legacy normalization was inflating score_data_loc values above their component scores (score_data and score_loc), violating expected scoring behavior where combined scores should not exceed components.


