### PR TITLE
perf: load Munsell color reference CSV once at startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 default_install_hook_types:
-    - pre-commit
-    - commit-msg
+-   pre-commit
+-   commit-msg
 
 repos:
-    - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-      rev: v0.8.0
-      hooks:
-          - id: pre-commit-update
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.9.0
+    hooks:
+    -   id: pre-commit-update
 
-    - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.14.0
-      hooks:
-          - id: ruff-check
-            args: [--fix]
-          - id: ruff-format
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+    -   id: ruff-check
+        args: [--fix]
+    -   id: ruff-format
 
-    - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v4.2.0
-      hooks:
-          - id: conventional-pre-commit
-            stages: [commit-msg]
-            args: []
+-   repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+    -   id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []

--- a/soil_id/color.py
+++ b/soil_id/color.py
@@ -32,7 +32,8 @@ def lab2munsell(color_ref, LAB_ref, lab):
     Returns:
     - str: Munsell color notation.
     """
-    idx = pd.DataFrame(euclidean_distances([lab], LAB_ref)).idxmin(axis=1).iloc[0]
+    distances = euclidean_distances([lab], LAB_ref)
+    idx = int(np.argmin(distances[0]))
     munsell_color = (
         f"{color_ref.at[idx, 'hue']} "
         f"{int(color_ref.at[idx, 'value'])}/{int(color_ref.at[idx, 'chroma'])}"

--- a/soil_id/config.py
+++ b/soil_id/config.py
@@ -15,6 +15,7 @@
 import os
 import tempfile
 
+import pandas as pd
 from dotenv import load_dotenv
 from platformdirs import user_cache_dir
 
@@ -42,6 +43,12 @@ US_AREA_PATH = f"{DATA_PATH}/SoilID_US_Areas.shz"
 # US Soil ID
 STATSGO_PATH = f"{DATA_PATH}/gsmsoilmu_a_us.shp"
 MUNSELL_RGB_LAB_PATH = f"{DATA_PATH}/LandPKS_munsell_rgb_lab.csv"
+
+# Pre-load Munsell color reference data once at startup
+MUNSELL_COLOR_REF = pd.read_csv(MUNSELL_RGB_LAB_PATH)
+MUNSELL_LAB_REF = MUNSELL_COLOR_REF[["cielab_l", "cielab_a", "cielab_b"]]
+MUNSELL_LAB_REF_NP = MUNSELL_LAB_REF.to_numpy()
+MUNSELL_REF = MUNSELL_COLOR_REF[["hue", "value", "chroma"]]
 
 # Database
 DB_NAME = os.environ.get("DB_NAME", "terraso_backend")

--- a/soil_id/us_soil.py
+++ b/soil_id/us_soil.py
@@ -81,10 +81,10 @@ class SoilListOutputData:
 #                                   list_soils                                 #
 ############################################################################################
 def list_soils(lon, lat):
-    # Load in LAB to Munsell conversion look-up table
-    color_ref = pd.read_csv(soil_id.config.MUNSELL_RGB_LAB_PATH)
-    LAB_ref = color_ref[["cielab_l", "cielab_a", "cielab_b"]]
-    munsell_ref = color_ref[["hue", "value", "chroma"]]
+    # LAB to Munsell conversion look-up table (loaded once at startup)
+    color_ref = soil_id.config.MUNSELL_COLOR_REF
+    LAB_ref = soil_id.config.MUNSELL_LAB_REF_NP
+    munsell_ref = soil_id.config.MUNSELL_REF
 
     out = get_soilweb_data(lon, lat)
 


### PR DESCRIPTION
This is not a critical change, but it does make things more efficient and it isn't particularly complicated.

The 8,500-row CSV was being read on every call to list_soils(). Now loaded once at module level in config.py. Also precompute the numpy array for LAB_ref and use np.argmin instead of pd.DataFrame.idxmin in lab2munsell to avoid repeated pandas overhead.

Not really sure if want the changes in .pre-commit-config.yaml, but let's see how the automated tests go.