### PR TITLE
feat: add munsell_to_lab lookup (Munsell -> CIELAB)

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,9 @@
 composition_stats
-gdal==3.11.4
+# Any 3.11.x, not an exact pin: the GDAL Python binding must match each
+# consumer's *system* libgdal, which differs by environment (e.g. this repo's
+# CI vs. terraso-backend). Apps pin the exact version; the library declares a
+# compatible range so it doesn't force one version on every consumer.
+gdal==3.11.*
 geopandas
 numpy
 pandas

--- a/soil_id/color.py
+++ b/soil_id/color.py
@@ -59,6 +59,31 @@ def munsell2rgb(color_ref, munsell_ref, munsell):
     return [color_ref.at[idx, col] for col in ["srgb_r", "srgb_g", "srgb_b"]]
 
 
+def munsell_to_lab(color_ref, munsell_ref, munsell):
+    """
+    Looks up CIELAB values for a Munsell color in the reference dataframe.
+
+    The inverse of lab2munsell, but an exact table lookup rather than a
+    nearest-neighbor match (an off-table color returns None).
+
+    Parameters:
+    - color_ref (pd.DataFrame): Reference dataframe with Munsell and CIELAB values.
+    - munsell_ref (pd.DataFrame): Reference dataframe with Munsell hue/value/chroma.
+    - munsell (list): Munsell values [hue, value, chroma], where hue is a string
+      (e.g. "7.5YR", or "N" for a neutral).
+
+    Returns:
+    - list: [L, A, B], or None if the color is not in the reference table.
+    """
+    matches = munsell_ref.query(
+        f'hue == "{munsell[0]}" & value == {int(munsell[1])} & chroma == {int(munsell[2])}'
+    )
+    if matches.empty:
+        return None
+    idx = matches.index[0]
+    return [color_ref.at[idx, col] for col in ["cielab_l", "cielab_a", "cielab_b"]]
+
+
 def convert_rgb_to_lab(row):
     """
     Converts RGB values to LAB.

--- a/soil_id/tests/test_color.py
+++ b/soil_id/tests/test_color.py
@@ -1,0 +1,34 @@
+# Copyright © 2024 Technology Matters
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see https://www.gnu.org/licenses/.
+
+import pytest
+
+from soil_id.color import munsell_to_lab
+from soil_id.config import MUNSELL_COLOR_REF, MUNSELL_REF
+
+
+def test_munsell_to_lab_known_color():
+    lab = munsell_to_lab(MUNSELL_COLOR_REF, MUNSELL_REF, ["7.5YR", 5, 4])
+    assert lab == pytest.approx([51.62524644, 9.878405711, 22.66377176])
+
+
+def test_munsell_to_lab_neutral():
+    lab = munsell_to_lab(MUNSELL_COLOR_REF, MUNSELL_REF, ["N", 8, 0])
+    assert lab == pytest.approx([82.04578167, 0.0, 0.0])
+
+
+def test_munsell_to_lab_off_table_returns_none():
+    # A physically implausible (out-of-gamut) color is not in the table.
+    assert munsell_to_lab(MUNSELL_COLOR_REF, MUNSELL_REF, ["10PB", 7, 33]) is None


### PR DESCRIPTION
moved munsell_to_lab to soil-id because it relies on a huge CSV file which soil-id already loads.
this PR itself should be easy to approve -- it is just adding a new function which nobody in soil-id calls.
a later PR will be calling this function from backend.
