### PR TITLE
fix: only show the dump/redistribute reminder for local soil-id DB writes

### DIFF
--- a/scripts/wrb_descriptions_sync.py
+++ b/scripts/wrb_descriptions_sync.py
@@ -388,6 +388,9 @@ def main():
                     f"have no JSON entry and would lose their description: {', '.join(missing)}"
                 )
             n_alter, n_insert = apply_write(conn, translations, args.sql_out)
+            with conn.cursor() as cur:
+                cur.execute("SELECT current_database()")
+                db_name = cur.fetchone()[0]
         print(
             f"Rebuilt wrb_fao90_desc from JSON: {n_alter} column op(s), deleted all rows, "
             f"inserted {n_insert} soils across {len(translations)} languages "
@@ -395,7 +398,11 @@ def main():
         )
         if args.sql_out:
             print(f"Wrote SQL to {args.sql_out}")
-        print("Next: regenerate the dump (make dump_soil_id_db) and redistribute it.")
+        # The dump -> soil-id-db image path only applies to the dedicated local soil-id
+        # database (named "soil_id"); a --write against the staging/prod primary DB is
+        # applied directly, so there is nothing to dump or redistribute.
+        if db_name == "soil_id":
+            print("Next: regenerate the dump (make dump_soil_id_db) and redistribute it.")
         return
 
     with psycopg.connect(args.database_url) as conn:


### PR DESCRIPTION
The `--write` footer ("Next: regenerate the dump … and redistribute it") is only meaningful for the **dedicated local soil-id DB** (named `soil_id`), which is dumped into the `soil-id-db` image for local dev + CI.

A `--write` against the **staging/prod primary database** applies the change directly — there's nothing to dump or redistribute — yet the line printed there too, which was confusing during the prod sync.

Fix: capture `current_database()` after the rebuild and only print the reminder when it's `soil_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)